### PR TITLE
reworkpixelfunction

### DIFF
--- a/code_new/s2tile_to_gibstiles.py
+++ b/code_new/s2tile_to_gibstiles.py
@@ -1,16 +1,14 @@
 import os
 from osgeo import gdal, osr
 import json
+import numpy as np
+import math
 import xml.etree.ElementTree as ET
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 gdal.UseExceptions()
-gdal.SetConfigOption("GDAL_VRT_ENABLE_PYTHON", "YES")
 
-
-basedir = "dir_path"
-basedir = "/home/ubuntu/hls-browse_imagery/code_new"
-basename = "HLS.S30.T01LAH.2020097T222759.v1.5"
+basedir = dir_path
 
 with open(os.path.join(basedir, "util", "format_params.json")) as f:
     params = json.load(f)
@@ -20,102 +18,127 @@ with open(os.path.join(basedir, "util", "lookup.json")) as f:
 
 
 # Pixel Function Template
-low_thresh = params["lower_threshold"]
-high_thresh = params["upper_threshold"]
+low_thresh = math.log(params["lower_threshold"])
+high_thresh = math.log(params["upper_threshold"])
 low_value = params["min_DN"]
 high_value = params["max_DN"]
-
-pixelfunc = f"""<![CDATA[
-import numpy as np
-def threshold(in_ar, out_ar, xoff, yoff, xsize, ysize, raster_xsize,
-                raster_ysize, buf_radius, gt, **kwargs):
-    low_thresh = np.log({low_thresh})
-    high_thresh = np.log({high_thresh})
-    low_value = {low_value}
-    high_value = {high_value}
-    diff = high_thresh - low_thresh
-    extracted_data = np.log(in_ar[0])
-    extracted_data[np.where(extracted_data <= low_thresh)] = low_value
-    extracted_data[np.where(extracted_data >= high_thresh)] = high_value
-    indices = np.where(
-        (extracted_data > low_thresh) & (extracted_data < high_thresh)
-    )
-    extracted_data[indices] = (
-        high_value * (extracted_data[indices] - low_thresh) / diff
-    )
-    out_ar = extracted_data
-]]>"""
+thresh_diff = high_thresh - low_thresh
+print(params, low_thresh, high_thresh, low_value, high_value, thresh_diff)
 
 
-def granule_vrt(basename):
-    out_file = "{}-color.vrt".format(basename)
+def basepath(basename):
+    if os.path.isdir(basename):
+        print("found directory", basename)
+        return basename
+
+    tstfile = "{}.B04.tif".format(basename)
+    if os.path.isfile(tstfile):
+        indir = os.path.dirname(tstfile)
+        print("found file in directory", indir)
+        return indir
+
+
+def create_gibs_tiles(basename, savevrt=False, outpath=None):
+    inpath = basepath(basename)
+    granulename = os.path.basename(basename)
+    if outpath is None:
+        outpath = os.path.join(basedir, "files")
+    print('saving data to', outpath)
+
+    if savevrt:
+        merge_vrt = os.path.join(outpath, "{}-color.vrt".format(granulename))
+    else:
+        merge_vrt = ""
     files = [
-        os.path.join(basedir,"files","{}.B04.tif".format(basename)),
-        os.path.join(basedir,"files","{}.B03.tif".format(basename)),
-        os.path.join(basedir,"files","{}.B02.tif".format(basename)),
+        os.path.join(inpath, "{}.B04.tif".format(granulename)),
+        os.path.join(inpath, "{}.B03.tif".format(granulename)),
+        os.path.join(inpath, "{}.B02.tif".format(granulename)),
     ]
     options = gdal.BuildVRTOptions(separate=True,)
-    ds = gdal.BuildVRT(out_file, files, options=options)
-    ds = None
-    return out_file
+    granule = gdal.BuildVRT(merge_vrt, files, options=options)
 
-
-def create_gibs_tiles(basename):
-    granule = gdal.Open(granule_vrt(basename))
-    grid = basename.split(".")[2][1:]
+    grid = granulename.split(".")[2][1:]
+    print("finding grid for", grid)
     gibs_tiles = lookup[grid]
+
     for g in gibs_tiles:
         gid = g["GID"]
         minlon = g["minlon"]
         minlat = g["minlat"]
         maxlon = g["maxlon"]
         maxlat = g["maxlat"]
+        if savevrt:
+            vrt_file = os.path.join(outpath, "{}_{}.vrt".format(granulename, gid))
+        else:
+            vrt_file = ""
 
-        vrt_file = "{}_{}.vrt".format(basename, gid)
-        pix_file = "{}_{}_pix.vrt".format(basename, gid)
-        tif_file = "{}_{}.tiff".format(basename, gid)
+        tif_file = os.path.join(outpath, "{}_{}.tif".format(granulename, gid))
+        print(outpath, tif_file)
 
+        print("creating warped vrt for", gid, minlon, minlat, maxlon, maxlat)
         vrt = gdal.Warp(
             vrt_file,
             granule,
-            dstSRS="EPSG:4326",
+            dstSRS="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs",
             format="VRT",
             outputBounds=(minlon, minlat, maxlon, maxlat),
             xRes=2.74658203125e-4,
             yRes=2.74658203125e-4,
-            srcNodata=-9999,
-            dstNodata=0,
-            #workingType=gdal.GDT_Int16,
-            #outputType=gdal.GDT_Byte,
-            srcAlpha=False,
             dstAlpha=True,
         )
-        # check statistics to see if there is any data in this tile
-        stats = False
-        for band in [1, 2, 3]:
-            try:
-                print(vrt.GetRasterBand(band).GetStatistics(0, 1))
-                stats = True
-            except:
-                print("no pixels found for ", gid)
-                break
-        vrt = None  # make sure to deallocate memory for layer
-        if not stats:
-            print("removing ", vrt_file)
-            os.unlink(vrt_file)
-            continue
 
-        tree = ET.parse(vrt_file)
-        for band in tree.findall("VRTRasterBand"):
-            ET.SubElement(band, "PixelFunctionType").text = "thresholds"
-            ET.SubElement(band, "PixelFunctionLanguage").text = "Python"
-            ET.SubElement(band, "PixelFunctionCode").text = pixelfunc
-        tree.write(pix_file)
+        cols = vrt.RasterXSize
+        rows = vrt.RasterYSize
 
         d = gdal.GetDriverByName("GTiff")
-        ds = gdal.Open(pix_file)
-        d.CreateCopy(tif_file, ds, 0, ["TILED=YES", "COMPRESS=LZW", "NBITS=8"])
-        ds = None
-        d = None
+        out = d.Create(
+            tif_file, cols, rows, 4, gdal.GDT_Byte, ["TILED=YES", "COMPRESS=LZW"]
+        )
+
+        out.SetGeoTransform(vrt.GetGeoTransform())
+        out.SetProjection(vrt.GetProjection())
+
+        # Rescale Data
+        valid = True
+        alpha_arr = np.zeros((cols, rows))
+        alpha_arr.fill(255)
+        print("stretching bands for ", gid)
+        for i in [1, 2, 3]:
+            band = vrt.GetRasterBand(i)
+            nodata = band.GetNoDataValue()
+            arr = band.ReadAsArray()
+            nodata_indices = np.where((arr == nodata) | (arr == 0))
+            alpha_arr[nodata_indices] = 0
+            arr = np.ma.masked_equal(arr, nodata)
+            if not np.any(arr):
+                print("no data found in band", i, gid)
+                out = None
+                os.unlink(tif_file)
+                break
+            arr = np.ma.log(arr)
+
+            arr[np.where(arr <= low_thresh)] = low_value
+            arr[np.where(arr >= high_thresh)] = high_value
+            indices = np.where((arr > low_thresh) & (arr < high_thresh))
+            arr[indices] = high_value * (arr[indices] - low_thresh) / thresh_diff
+            arr[nodata_indices] = 0
+
+            # write the data out to new band in tif
+            new_band = out.GetRasterBand(i)
+            new_band.WriteArray(arr, 0, 0)
+            new_band.SetNoDataValue(0)
+            new_band.GetStatistics(0, 1)
+
+            band = None
+
+        if out is not None:
+            new_band = out.GetRasterBand(4)
+            new_band.WriteArray(alpha_arr, 0, 0)
+            new_band.GetStatistics(0, 1)
+
+        out = None
+        band = None
+        arr = None
+        alpha_arr = None
 
     granule = None  # make sure to deallocate memory for layer


### PR DESCRIPTION
Move image enhancement out of pixel function. Add better handling for paths.

create_gibs_tiles now takes two optional arguments:
savevrt=False -- if set to true it will output the intermediate vrt files
outputpath=<location of directory to store the data> set to put the data anywhere on the filesystem, the directory must exist, defaults to code_new/files/

The argument for the basename can take a full path and will detect if it is the name of a directory, or the truncated name of a file.
