### PR TITLE
fix: relax dependencies for container update

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,14 @@ from setuptools import setup, find_packages
 
 setup(
     name="hls_browse_imagery_creator",
-    version="0.1",
+    version="1.8",
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
     install_requires=[
         "numpy",
         "gdal",
         "xmltodict",
-        "click~=7.1.0",
+        "click",
         "dicttoxml",
         "lxml"
     ],


### PR DESCRIPTION
## Description

This PR relaxes the Click dependency so this can be installed against a more modern set of dependencies in our atmospheric correction container.